### PR TITLE
feat(SLB-585): add focal point GraphQL directive and data producer

### DIFF
--- a/src/Plugin/GraphQL/DataProducer/FocalPoint.php
+++ b/src/Plugin/GraphQL/DataProducer/FocalPoint.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Drupal\silverback_gatsby\Plugin\GraphQL\DataProducer;
+
+use Drupal\graphql\Plugin\GraphQL\DataProducer\DataProducerPluginBase;
+use Drupal\crop\Entity\Crop;
+use Drupal\Core\StreamWrapper\PublicStream;
+
+/**
+ * @DataProducer(
+ *   id = "focal_point",
+ *   name = @Translation("Focal Point"),
+ *   description = @Translation("Retrieve focal point coordinates for an image source."),
+ *   produces = @ContextDefinition("any",
+ *     label = @Translation("Image properties")
+ *   ),
+ *   consumes = {
+ *     "image_props" = @ContextDefinition("any",
+ *       label = @Translation("Image Props"),
+ *       required = FALSE
+ *     )
+ *   }
+ * )
+ */
+class FocalPoint extends DataProducerPluginBase {
+    /**
+     * Resolver to return the focal point coordinates.
+     *
+     * @param array $image_props
+     *
+     * @return array|null
+     */
+    public function resolve(array $image_props = NULL) {
+        $path = parse_url($image_props['src']);
+        $publicFilesDirectory = '/' . PublicStream::basePath();
+        // Reverse-engineer the public path to find the crop.
+        $public = 'public:/' . substr($path['path'], strlen($publicFilesDirectory));
+        $crop = Crop::findCrop($public, 'focal_point');
+        $x = $crop?->x->value;
+        $y = $crop?->y->value;
+        $image_props['focalPoint'] = $x && $y ? [
+            'x' => $x,
+            'y' => $y,
+        ] : NULL;
+        return $image_props;
+    }
+}

--- a/src/Plugin/GraphQL/Directive/FocalPoint.php
+++ b/src/Plugin/GraphQL/Directive/FocalPoint.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Drupal\silverback_gatsby\Plugin\GraphQL\Directive;
+
+use Drupal\Core\Plugin\PluginBase;
+use Drupal\graphql\GraphQL\Resolver\ResolverInterface;
+use Drupal\graphql\GraphQL\ResolverBuilder;
+use Drupal\graphql_directives\DirectiveInterface;
+
+/**
+ * @Directive(
+ *   id = "focalPoint",
+ *   description = "Retrieve focal point coordinates for an image source.",
+ *   arguments = {}
+ * )
+ */
+class FocalPoint extends PluginBase implements DirectiveInterface {
+
+    /**
+     * {@inheritDoc}
+     * @throws \Exception
+     */
+    public function buildResolver(ResolverBuilder $builder, array $arguments): ResolverInterface {
+        return $builder->produce('focal_point')->map('image_props', $builder->fromParent());
+    }
+
+}


### PR DESCRIPTION
Provide a focal point directive to be used with the focal_point Drupal module. It returns coordinates that will then be translated to a focus area in Gatsby, but future image features will provide coordinate-specific cropping, so we'll keep the API returning coordinates, as the focus area will become redundant.